### PR TITLE
[ZEPPELIN-658] Scala: not accepting companion objects if defined in d…

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -774,13 +774,34 @@ public class SparkInterpreter extends Interpreter {
     context.out.clear();
     Code r = null;
     String incomplete = "";
+    boolean inComment = false;
 
     for (int l = 0; l < linesToRun.length; l++) {
       String s = linesToRun[l];
       // check if next line starts with "." (but not ".." or "./") it is treated as an invocation
       if (l + 1 < linesToRun.length) {
         String nextLine = linesToRun[l + 1].trim();
-        if (nextLine.startsWith(".") && !nextLine.startsWith("..") && !nextLine.startsWith("./")) {
+        boolean continuation = false;
+        if (nextLine.isEmpty()
+           || nextLine.startsWith("//")         // skip empty line or comment
+           || nextLine.startsWith("}")
+           || nextLine.startsWith("object")) {  // include "} object" for Scala companion object
+          continuation = true;
+        } else if (!inComment && nextLine.startsWith("/*")) {
+          inComment = true;
+          continuation = true;
+        } else if (inComment && nextLine.lastIndexOf("*/") >= 0) {
+          inComment = false;
+          continuation = true;
+        } else if (nextLine.length() > 1
+                && nextLine.charAt(0) == '.'
+                && nextLine.charAt(1) != '.'     // ".."
+                && nextLine.charAt(1) != '/') {  // "./"
+          continuation = true;
+        } else if (inComment) {
+          continuation = true;
+        }
+        if (continuation) {
           incomplete += s + "\n";
           continue;
         }

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -142,6 +142,17 @@ public class SparkInterpreterTest {
   }
 
   @Test
+  public void testNextLineComments() {
+    assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("\"123\"\n/*comment here\n*/.toInt", context).code());
+  }
+
+  @Test
+  public void testNextLineCompanionObject() {
+    String code = "class Counter {\nvar value: Long = 0\n}\n // comment\n\n object Counter {\n def apply(x: Long) = new Counter()\n}";
+    assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret(code, context).code());
+  }
+
+  @Test
   public void testEndWithComment() {
     assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("val c=1\n//comment", context).code());
   }


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://github.com/apache/incubator-zeppelin/blob/master/CONTRIBUTING.md


### What type of PR is it?
[Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?

…ifferent lines

### What is this PR for?
In Scala, a singleton companion object can be defined along the class. Because of the way code lines are split, the interpreter is not passing the companion object along with the class code, or indicating any possible line continuation (eg. leaving out '}'). This causes an error with the Scala REPL/compiler.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Fix line splitting
* [x] - Add tests

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-658
https://issues.apache.org/jira/browse/ZEPPELIN-747

### How should this be tested?
Add a new paragraph with Scala/Spark interpreter and define a class with its companion object.
See bug for more details

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

Author: Felix Cheung <felixcheung_m@hotmail.com>

Closes #780 from felixcheung/scalarepl and squashes the following commits:

5087dae [Felix Cheung] check for continuation